### PR TITLE
Fixed instagram API uri's

### DIFF
--- a/connected_accounts/providers/instagram.py
+++ b/connected_accounts/providers/instagram.py
@@ -30,8 +30,8 @@ class InstagramProvider(OAuth2Provider):
     name = _('Instagram')
     account_class = InstagramAccount
 
-    access_token_url = 'https://instagram.com/oauth/access_token'
-    authorization_url = 'https://instagram.com/oauth/authorize'
+    access_token_url = 'https://api.instagram.com/oauth/access_token'
+    authorization_url = 'https://api.instagram.com/oauth/authorize'
     profile_url = 'https://api.instagram.com/v1/users/self'
 
     consumer_key = settings.CONNECTED_ACCOUNTS_INSTAGRAM_CONSUMER_KEY


### PR DESCRIPTION
I was experiencing the problems connecting to Instagram found that the API uri was broken according to the following comment:
http://stackoverflow.com/a/34145598

I fixed the uri and it all worked.
